### PR TITLE
docs: add documentation of available npm scripts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,21 @@ Design clean and accessible interfaces:
 
 ---
 
+## Available Scripts
+
+- `npm run dev`: starts the development server using Vite.
+- `npm run build`: compiles TypeScript and builds the project for production using Vite.
+- `npm run preview`: serves the production build for preview using Vite.
+- `npm run lint`: runs ESLint to check for coding style issues according to `.eslint.config.js`
+- `npm run lint:fix`: runs ESLint and automatically fixes any fixable issues.
+- `npm run format`: formats the code using Prettier based on the `.prettierrc` configuration.
+- `npm run format:check`: checks that the code is properly formatted using Prettier.
+- `npm run stylelint`: checks and fixes `.css` files using Stylelint.
+- `npm run test`: runs all tests using Jest.
+- `npm run test:watch`: runs tests in watch mode using Jest.
+- `npm run test:coverage`: runs tests and generates a coverage report using Jest.
+- `npm run prepare`: initializes Husky to enable Git pre-commit hooks.
+
+---
+
 ## Team project by [Victor](https://github.com/GrigorevVic), [Nursultan](https://github.com/qwavy) and [Vasiliy](https://github.com/VasiliyAlex)


### PR DESCRIPTION
1. Task: [Repository Setup, Project Management, CommerceTools Integration, and Development Environment Configuration](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%231.md).
2. Subtask: [Comprehensive README](https://github.com/users/GrigorevVic/projects/6?pane=issue&itemId=108398678&issue=GrigorevVic%7Ce-com-app%7C6).
3. Screenshot :
![Снимок экрана 2025-05-03 212342](https://github.com/user-attachments/assets/3bee6606-062a-4ee8-91d7-d159f89e6887)
4. Comprehensive README (19 points):
- [x] **(5 points)** Clearly document all available scripts and their usage in the README file. 