### PR TITLE
feat: add image slider for viewing multiple product images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mantine/hooks": "^8.0.0",
         "@mantine/notifications": "^8.0.1",
         "@tanstack/react-query": "^5.76.1",
+        "embla-carousel-react": "^8.6.0",
         "mobx-react-lite": "^4.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6334,6 +6335,34 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.152.tgz",
       "integrity": "sha512-xBOfg/EBaIlVsHipHl2VdTPJRSvErNUaqW8ejTq5OlOlIYx1wOllCHsAvAIrr55jD1IYEfdR86miUEt8H5IeJg==",
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@mantine/hooks": "^8.0.0",
     "@mantine/notifications": "^8.0.1",
     "@tanstack/react-query": "^5.76.1",
+    "embla-carousel-react": "^8.6.0",
     "mobx-react-lite": "^4.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/shared/utils/get-price.ts
+++ b/src/shared/utils/get-price.ts
@@ -1,5 +1,0 @@
-import { TypedMoney } from '@commercetools/platform-sdk';
-
-export const getPrice = (priceObj: TypedMoney) => {
-  return (priceObj.centAmount / Math.pow(10, priceObj?.fractionDigits)).toFixed(priceObj.fractionDigits);
-};

--- a/src/widgets/product-details/ui/product-details.module.css
+++ b/src/widgets/product-details/ui/product-details.module.css
@@ -23,19 +23,6 @@
   border-radius: 10px;
 }
 
-.main-image {
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  aspect-ratio: 1 / 1;
-  width: 100%;
-  border-radius: 10px;
-
-  background-color: var(--color-gray);
-}
-
 .content {
   display: flex;
   flex-direction: column;
@@ -67,12 +54,57 @@
   background-color: var(--color-gray);
 }
 
-.images {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 10px;
-  justify-content: flex-start;
-
+.slider-wrapper {
   width: 100%;
-  margin-top: 30px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.embla {
+  overflow: hidden;
+  width: 100%;
+}
+
+.embla-container {
+  display: flex;
+}
+
+.embla-slide {
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  box-sizing: border-box;
+  aspect-ratio: 1 / 1;
+  min-width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+
+  background-color: var(--color-gray);
+}
+
+.thumbnails {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+
+  margin-top: 10px;
+}
+
+.thumbnail {
+  cursor: pointer;
+
+  width: 100px;
+  height: 100px;
+  border: 2px solid transparent;
+  border-radius: 8px;
+
+  object-fit: contain;
+  background: var(--color-gray);
+}
+
+.thumbnail.active {
+  border-color: #228be6;
 }

--- a/src/widgets/product-details/ui/product-details.tsx
+++ b/src/widgets/product-details/ui/product-details.tsx
@@ -1,12 +1,12 @@
 import { ProductPrice } from '@entities/product/ui/product-price';
 import { BasketButton } from '@features/basket-button/index';
 import { FavoriteButton } from '@features/favorite-button/index';
-import { Group, Image, Skeleton, Text } from '@mantine/core';
+import { Group, Skeleton, Text } from '@mantine/core';
 import { useProductDetails } from '@shared/api/endpoints/product/get-product';
-// import { getPrice } from '@shared/utils/get-price';
 import { useParams } from 'react-router-dom';
 
 import styles from './product-details.module.css';
+import { ImageSlider } from './slider';
 
 export const ProductDetails = () => {
   const { id } = useParams<{ id: string }>();
@@ -22,32 +22,13 @@ export const ProductDetails = () => {
   }
   const priceObj = productInfo.masterVariant.prices?.[0]?.value;
   const discountedPriceObj = productInfo.masterVariant.prices?.[0]?.discounted?.value;
-  const imageObj = productInfo.masterVariant.images?.[0]?.url;
 
   return (
     <Skeleton visible={isPending}>
       <Group className={styles.container}>
         <div className={styles.box}>
           <div className={styles.image}>
-            <div className={styles['main-image']}>
-              <Image src={imageObj} alt={productInfo.name.en} fit="contain" style={{ width: '70%', height: '70%' }} />
-            </div>
-            <Group className={styles.images}>
-              {productInfo?.masterVariant.images?.map((img, index) => (
-                <Image
-                  key={index}
-                  src={img.url}
-                  alt={`Image ${index + 1}`}
-                  style={{
-                    width: '100px',
-                    objectFit: 'contain',
-                    borderRadius: '8px',
-                    height: '100px',
-                    backgroundColor: 'var(--color-gray)',
-                  }}
-                />
-              ))}
-            </Group>
+            <ImageSlider images={productInfo.masterVariant.images || []} alt={productInfo.name.en} />
           </div>
           <div className={styles.content}>
             <Text size="xl" fw={600}>

--- a/src/widgets/product-details/ui/slider.tsx
+++ b/src/widgets/product-details/ui/slider.tsx
@@ -1,0 +1,58 @@
+import { Image } from '@mantine/core';
+import useEmblaCarousel from 'embla-carousel-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import styles from './product-details.module.css';
+
+interface ImageSliderProps {
+  images: { url: string }[];
+  alt?: string;
+}
+
+export const ImageSlider = ({ images, alt = 'Product image' }: ImageSliderProps) => {
+  const [emblaRef, emblaApi] = useEmblaCarousel();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const scrollTo = useCallback(
+    (index: number) => {
+      if (emblaApi) {
+        emblaApi.scrollTo(index);
+      }
+    },
+    [emblaApi],
+  );
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return;
+    }
+    const onSelect = () => setSelectedIndex(emblaApi.selectedScrollSnap());
+    emblaApi.on('select', onSelect);
+    onSelect();
+  }, [emblaApi]);
+
+  return (
+    <div className={styles['slider-wrapper']}>
+      <div className={styles.embla} ref={emblaRef}>
+        <div className={styles['embla-container']}>
+          {images.map((img, index) => (
+            <div className={styles['embla-slide']} key={index}>
+              <Image src={img.url} alt={`${alt} ${index + 1}`} fit="contain" style={{ width: '70%', height: '70%' }} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className={styles.thumbnails}>
+        {images.map((img, index) => (
+          <img
+            key={index}
+            src={img.url}
+            alt={`Thumbnail ${index + 1}`}
+            onClick={() => scrollTo(index)}
+            className={`${styles.thumbnail} ${index === selectedIndex ? styles.active : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%231.md).
1. Task: [Catalog Product Page, Detailed Product Page & User Profile Page Implementation](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%233.md).
2. Subtask: [Display Product Information](https://github.com/users/GrigorevVic/projects/6/views/1?pane=issue&itemId=111485212&issue=GrigorevVic%7Ce-com-app%7C76).
3. Screenshot : ![Снимок экрана 2025-05-30 232439](https://github.com/user-attachments/assets/c1e063bc-6755-44ee-8f2f-31daea224287)
4. Display Product Information (65/65 points):

- [x] **(25 points)** Use the commercetools API to fetch and display the product name, description, and images on the Detailed Product page.
- [x] **(25 points)** Implement an image slider for product images fetched from the chosen API, allowing users to view multiple images of the product.
- [x] **(15 points)** Display the product price fetched from the chosen API, and if the product is on sale, display both the original and discounted prices.

